### PR TITLE
cmd/flow: fix ip version when CIDR is v6

### DIFF
--- a/internal/cmd/flow/flow.go
+++ b/internal/cmd/flow/flow.go
@@ -58,8 +58,8 @@ func New() *cobra.Command {
 			if ((srcIP.To4() == nil) && (dstIP.To4() != nil)) || ((srcIP.To4() != nil) && (dstIP.To4() == nil)) {
 				return errors.New("source and destination CIDR IP version mismatch")
 			}
-			if srcIP.To4() != nil {
-				opts.ipVersion = flowpb.IPVersion_IPv4
+			if srcIP.To4() == nil {
+				opts.ipVersion = flowpb.IPVersion_IPv6
 			}
 
 			var printerOpts []printer.Option


### PR DESCRIPTION
The IP version was incorrectly set to IPv4 when source/destination CIDR is IPv6. This commit ensures it is correctly set to IPv6 in such cases.