### PR TITLE
fake: preserve flow structure over json

### DIFF
--- a/json_test.go
+++ b/json_test.go
@@ -1,0 +1,50 @@
+// Copyright (C) Isovalent, Inc. - All Rights Reserved.
+//
+// NOTICE: All information contained herein is, and remains the property of
+// Isovalent Inc and its suppliers, if any. The intellectual and technical
+// concepts contained herein are proprietary to Isovalent Inc and its suppliers
+// and may be covered by U.S. and Foreign Patents, patents in process, and are
+// protected by trade secret or copyright law.  Dissemination of this information
+// or reproduction of this material is strictly forbidden unless prior written
+// permission is obtained from Isovalent Inc.
+package fake
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	observerpb "github.com/cilium/cilium/api/v1/observer"
+)
+
+func doTestFakeJSON(t *testing.T) {
+	flow := Flow()
+	resp1 := observerpb.GetFlowsResponse{
+		NodeName: "test-node",
+		Time:     flow.Time,
+		ResponseTypes: &observerpb.GetFlowsResponse_Flow{
+			Flow: flow,
+		},
+	}
+
+	b, err := json.Marshal(&resp1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var resp2 observerpb.GetFlowsResponse
+	if err := json.Unmarshal(b, &resp2); err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(resp1.ResponseTypes, resp2.ResponseTypes) {
+		t.FailNow()
+	}
+
+}
+
+func Test_JSON(t *testing.T) {
+	for i := 0; i < 1000; i++ {
+		doTestFakeJSON(t)
+	}
+}

--- a/names.go
+++ b/names.go
@@ -47,6 +47,9 @@ func Name() string {
 // Names generates a random set of names. Panic when max <= 0.
 func Names(max int) []string {
 	n := rand.Intn(max + 1)
+	if n == 0 {
+		return nil
+	}
 	names := make([]string, n)
 	for i := 0; i < n; i++ {
 		names[i] = Name()


### PR DESCRIPTION
Currently, marshaling and unmarshalling a fake flow using json might
result in flows that are not reflect-deeply equal.

Specifically, "https://github.com/go-test/deep", reports:
[DestinationNames: <nil slice> != []

Ensure that flows remain deeply-equal when going over json
marhsalling/unmarshalling, and, also, add a test to that effect.

Signed-off-by: Kornilios Kourtis <kornilios@isovalent.com>