### PR TITLE
ci: fix the go vendoring check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,4 +40,4 @@ jobs:
         go mod tidy
         go mod vendor
         go mod verify
-        git diff --exit-code
+        test -z "$(git status --porcelain)" || (echo "please run 'go mod tidy && go mod vendor', and submit your changes"; exit 1)


### PR DESCRIPTION
Before this patch, git diff was used to ensure that Go modules were properly vendored. While it could catch a failure to update a vendored module, it would not fail when a module was not vendored (untracked).

This patch used git status instead of git diff, effectively catching untracked vendored modules as well.

Signed-off-by: Alexandre Perrin <alex@kaworu.ch>