### PR TITLE
allow to generate maximum port number

### DIFF
--- a/port.go
+++ b/port.go
@@ -72,5 +72,5 @@ func Port(options ...PortOption) uint32 {
 	for _, opt := range options {
 		opt.apply(&opts)
 	}
-	return uint32(rand.Intn(opts.max-opts.min) + opts.min)
+	return uint32(rand.Intn(opts.max+1-opts.min) + opts.min)
 }


### PR DESCRIPTION
`math/rand.Intn(n)` returns an integer from the half-open interval [0,n).
Thus, in its current implementation `func Port` can never return the
maximum port number. Fix this by increasing the interval endpoint by 1.