### PR TITLE
main: let Names always return non-nil slice

### DIFF
--- a/names.go
+++ b/names.go
@@ -52,7 +52,7 @@ func Name() string {
 func Names(max int) []string {
 	n := rand.Intn(max + 1)
 	if n == 0 {
-		return nil
+		return []string{}
 	}
 	names := make([]string, n)
 	for i := 0; i < n; i++ {

--- a/names_test.go
+++ b/names_test.go
@@ -15,7 +15,6 @@
 package fake_test
 
 import (
-	"math/rand"
 	"testing"
 
 	"github.com/cilium/fake"
@@ -31,10 +30,11 @@ func TestNames(t *testing.T) {
 	_ = fake.Names(-1)
 
 	names := fake.Names(0)
-	assert.Nil(t, names)
+	assert.NotNil(t, names)
+	assert.Equal(t, len(names), 0)
 
 	max := 100
-	names = fake.Names(rand.Intn(max + 1))
+	names = fake.Names(max)
 	assert.NotNil(t, names)
 	assert.LessOrEqual(t, len(names), max)
 	for _, n := range names {


### PR DESCRIPTION
In case n is 0 in Names, a nil slice would be returned which could make
dealing with the result unnecessarily cumbersome. Let's just return a
non-nil slice in all cases, with the special case returning an empty
slice.

Reference: https://github.com/cilium/fake/pull/17#pullrequestreview-859381695
Suggested-by: Alexandre Perrin <alex@kaworu.ch>
Signed-off-by: Tobias Klauser <tobias@cilium.io>