### PR TITLE
flow: add endpoint workload

### DIFF
--- a/flow/endpoint.go
+++ b/flow/endpoint.go
@@ -14,6 +14,7 @@ type endpointOptions struct {
 	namespace string
 	podName   string
 	labels    []string
+	workloads map[string]string
 }
 
 // EndpointOption is an option to use with Endpoint.
@@ -49,6 +50,17 @@ func WithEndpointLabels(labels []string) EndpointOption {
 	})
 }
 
+// WithEndpointWorkloads sets the endpoint workloads. The map's keys are the
+// workload names, and values are the workload kind.
+func WithEndpointWorkloads(workloads map[string]string) EndpointOption {
+	return funcEndpointOption(func(o *endpointOptions) {
+		o.workloads = make(map[string]string, len(workloads))
+		for name, kind := range workloads {
+			o.workloads[name] = kind
+		}
+	})
+}
+
 // Endpoint generates a random Endpoint. Options may be provided to customize
 // the endpoint to return.
 func Endpoint(options ...EndpointOption) *flowpb.Endpoint {
@@ -56,6 +68,7 @@ func Endpoint(options ...EndpointOption) *flowpb.Endpoint {
 		namespace: fake.K8sNamespace(),
 		podName:   fake.K8sPodName(),
 		labels:    fake.K8sLabels(),
+		workloads: fakeWorkloads(),
 	}
 	for _, opt := range options {
 		opt.apply(&opts)
@@ -67,5 +80,39 @@ func Endpoint(options ...EndpointOption) *flowpb.Endpoint {
 		Namespace: opts.namespace,
 		PodName:   opts.podName,
 		Labels:    opts.labels,
+		Workloads: workloadsFromMap(opts.workloads),
 	}
+}
+
+// see https://github.com/cilium/cilium/blob/d6483e1d26052b7f210a746ff85e919b76c9430f/pkg/k8s/utils/workload.go#L32
+var workloadKinds []string = []string{
+	"CronJob",
+	"DaemonSet",
+	"Deployment",
+	"DeploymentConfig",
+	"ReplicaSet",
+}
+
+func fakeWorkloads() map[string]string {
+	workloads := map[string]string{
+		fake.App(): workloadKinds[rand.Intn(len(workloadKinds))],
+	}
+	if rand.Intn(10) == 0 { // 10% chance of having more than one workload.
+		workloads[fake.App()] = workloadKinds[rand.Intn(len(workloadKinds))]
+	}
+	if rand.Intn(100) == 0 { // 1% chance of having more than two workloads.
+		workloads[fake.App()] = workloadKinds[rand.Intn(len(workloadKinds))]
+	}
+	return workloads
+}
+
+func workloadsFromMap(m map[string]string) []*flowpb.Workload {
+	workloads := make([]*flowpb.Workload, 0, len(m))
+	for name, kind := range m {
+		workloads = append(workloads, &flowpb.Workload{
+			Name: name,
+			Kind: kind,
+		})
+	}
+	return workloads
 }

--- a/flow/json_test.go
+++ b/flow/json_test.go
@@ -42,6 +42,7 @@ func Test_JSON(t *testing.T) {
 			cmpopts.IgnoreUnexported(
 				flowpb.CiliumEventType{},
 				flowpb.Endpoint{},
+				flowpb.Workload{},
 				flowpb.Ethernet{},
 				flowpb.Flow{},
 				flowpb.ICMPv4{},


### PR DESCRIPTION
We got some improvements about endpoint workloads recently on the Cilium side, (see [this PR](https://github.com/cilium/cilium/pull/21039) and [this PR](https://github.com/cilium/cilium/pull/21124)) and `fake` lack endpoint workloads support (not sure why they were missing before this patch, probably forgotten).