### PR TITLE
Add support for Go 1.21, drop support for Go 1.19

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Run static checks
       uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
       with:
-        version: v1.51.1
+        version: v1.54.2
         args: --config=.golangci.yml --verbose --out-${NO_FUTURE}format colored-line-number
         skip-cache: true
     - name: Check module tidiness
@@ -57,7 +57,7 @@ jobs:
       uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
       with:
         working-directory: ./cmd
-        version: v1.51.1
+        version: v1.54.2
         args: --config=../.golangci.yml --verbose --out-${NO_FUTURE}format colored-line-number
         skip-cache: true
     - name: Check module tidiness
@@ -88,7 +88,7 @@ jobs:
       uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
       with:
         working-directory: ./flow
-        version: v1.51.1
+        version: v1.54.2
         args: --config=../.golangci.yml --verbose --out-${NO_FUTURE}format colored-line-number
         skip-cache: true
     - name: Check module tidiness

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
   main:
     strategy:
       matrix:
-        go-version: ["1.19", "1.20"]
+        go-version: ["1.20", "1.21"]
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
@@ -41,7 +41,7 @@ jobs:
   cmd:
     strategy:
       matrix:
-        go-version: ["1.19", "1.20"]
+        go-version: ["1.20", "1.21"]
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
@@ -72,7 +72,7 @@ jobs:
   flow:
     strategy:
       matrix:
-        go-version: ["1.19", "1.20"]
+        go-version: ["1.20", "1.21"]
     runs-on: ubuntu-latest
     steps:
     - name: Install Go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,8 @@
 # See https://golangci-lint.run/usage/configuration/ for available options.
-# Also https://github.com/cilium/cilium/blob/master/.golangci.yaml as a
+# Also https://github.com/cilium/cilium/blob/main/.golangci.yaml as a
 # reference.
 run:
-  go: '1.20'
+  go: '1.21'
 linters:
   disable-all: true
   enable:
@@ -40,6 +40,7 @@ linters:
     - ineffassign
     - interfacebloat
     - makezero
+    - mirror
     - misspell
     - musttag
     - nakedret
@@ -54,6 +55,7 @@ linters:
     - revive
     - rowserrcheck
     - staticcheck
+    - tagalign
     - tenv
     - thelper
     - tparallel

--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -1,6 +1,6 @@
 module github.com/cilium/fake/cmd
 
-go 1.19
+go 1.20
 
 require (
 	github.com/cilium/cilium v1.14.0

--- a/flow/go.mod
+++ b/flow/go.mod
@@ -1,6 +1,6 @@
 module github.com/cilium/fake/flow
 
-go 1.19
+go 1.20
 
 require (
 	github.com/cilium/cilium v1.14.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cilium/fake
 
-go 1.19
+go 1.20
 
 require github.com/stretchr/testify v1.8.4
 


### PR DESCRIPTION
While here, also bump golangci-lint to v1.54.2.