### PR TITLE
flow: fix off by 1 error AuthType, TrafficDirection and SockXlatePoint

### DIFF
--- a/flow/auth.go
+++ b/flow/auth.go
@@ -11,5 +11,5 @@ import (
 
 // AuthType generates a random AuthType.
 func AuthType() flowpb.AuthType {
-	return flowpb.AuthType(rand.Intn(len(flowpb.AuthType_name) + 1))
+	return flowpb.AuthType(rand.Intn(len(flowpb.AuthType_name)))
 }

--- a/flow/flow.go
+++ b/flow/flow.go
@@ -233,7 +233,7 @@ func New(options ...Option) *flowpb.Flow {
 		DropReasonDesc:        opts.dropReason,
 		IsReply:               IsReply(),
 		TraceContext:          tc,
-		SockXlatePoint:        flowpb.SocketTranslationPoint(rand.Intn(len(flowpb.SocketTranslationPoint_name) + 1)),
+		SockXlatePoint:        flowpb.SocketTranslationPoint(rand.Intn(len(flowpb.SocketTranslationPoint_name))),
 		SocketCookie:          rand.Uint64(),
 		CgroupId:              rand.Uint64(),
 		// NOTE: don't populate Summary as it is deprecated.

--- a/flow/traffic.go
+++ b/flow/traffic.go
@@ -11,5 +11,5 @@ import (
 
 // TrafficDirection generates a random TrafficDirection.
 func TrafficDirection() flowpb.TrafficDirection {
-	return flowpb.TrafficDirection(rand.Intn(len(flowpb.TrafficDirection_name) + 1))
+	return flowpb.TrafficDirection(rand.Intn(len(flowpb.TrafficDirection_name)))
 }


### PR DESCRIPTION
AuthType, SockXlatePoint and TrafficDirection values where sometimes out of range by 1 value due as `rand.Intn` returns an open interval, which is actually what we want when passing the length of an array as parameter so that we actually get an index value.