### PR TITLE
cmd: export root command constructor

### DIFF
--- a/cmd/internal/cmd/root.go
+++ b/cmd/internal/cmd/root.go
@@ -75,8 +75,3 @@ func New() *cobra.Command {
 
 	return rootCmd
 }
-
-// Execute creates the root command and executes it.
-func Execute() error {
-	return New().Execute()
-}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,12 +8,16 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/cilium/fake/cmd/internal/cmd"
+	"github.com/cilium/fake/cmd/root"
 )
 
 func main() {
-	if err := cmd.Execute(); err != nil {
+	if err := execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
+}
+
+func execute() error {
+	return root.New().Execute()
 }

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// Package root exposes the root command for the fake CLI.
+package root
+
+import (
+	"github.com/cilium/fake/cmd/internal/cmd"
+	"github.com/spf13/cobra"
+)
+
+// New creates a new root command.
+func New() *cobra.Command {
+	return cmd.New()
+}


### PR DESCRIPTION
This provides access to the fake Command to downstream users that wants to build on top of the fake CLI.