### PR TITLE
renovate: group golangci-lint updates into a single PR

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -75,6 +75,16 @@
       ],
     },
     {
+      groupName: 'golangci-lint',
+      matchDepNames: [
+        'golangci/golangci-lint',
+      ],
+      addLabels: [
+        'area/build',
+        'release-note/misc',
+      ],
+    },
+    {
       groupName: 'Go',
       matchDepNames: [
         'docker.io/library/golang',


### PR DESCRIPTION
Renovate was opening separate PRs for golangci-lint when it appeared in multiple files.