### PR TITLE
cmd/flow: validate nodes-count before generation

### DIFF
--- a/cmd/internal/cmd/flow/flow.go
+++ b/cmd/internal/cmd/flow/flow.go
@@ -111,6 +111,9 @@ func runFlows(p *printer.Printer) error {
 	if opts.count < 1 {
 		return errors.New("--count must be at least 1")
 	}
+	if opts.nodesCount < 1 {
+		return errors.New("--nodes-count must be at least 1")
+	}
 	if !until.After(since) {
 		return errors.New("--since must come before --until")
 	}

--- a/cmd/internal/cmd/flow/flow_test.go
+++ b/cmd/internal/cmd/flow/flow_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package flow
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+	"time"
+
+	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/hubble/pkg/printer"
+)
+
+func TestRunFlowsRejectsInvalidNodeCounts(t *testing.T) {
+	t.Cleanup(resetOpts)
+
+	for _, nodesCount := range []int{0, -1} {
+		t.Run("nodes-count="+strconv.Itoa(nodesCount), func(t *testing.T) {
+			var out bytes.Buffer
+			p := printer.New(printer.JSONPB(), printer.Writer(&out))
+			t.Cleanup(func() { p.Close() })
+
+			opts.count = 1
+			opts.nodesCount = nodesCount
+			opts.since = time.Hour
+			opts.until = 0
+			opts.sourceCIDR = "10.0.0.0/8"
+			opts.destCIDR = "10.0.0.0/8"
+			opts.ipVersion = 0
+
+			err := runFlows(p)
+			if err == nil || err.Error() != "--nodes-count must be at least 1" {
+				t.Fatalf("expected invalid nodes-count error, got %v", err)
+			}
+			if out.Len() != 0 {
+				t.Fatalf("expected no output, got %q", out.String())
+			}
+		})
+	}
+}
+
+func TestRunFlowsGeneratesOutput(t *testing.T) {
+	t.Cleanup(resetOpts)
+
+	var out bytes.Buffer
+	p := printer.New(printer.JSONPB(), printer.Writer(&out))
+	t.Cleanup(func() { p.Close() })
+
+	opts.count = 1
+	opts.nodesCount = 1
+	opts.since = time.Hour
+	opts.until = 0
+	opts.sourceCIDR = "10.0.0.0/8"
+	opts.destCIDR = "10.0.0.0/8"
+
+	err := runFlows(p)
+	if err != nil {
+		t.Fatalf("runFlows returned error: %v", err)
+	}
+	if out.Len() == 0 {
+		t.Fatal("expected generated flow output")
+	}
+}
+
+func resetOpts() {
+	opts = struct {
+		output               string
+		count                int
+		nodesCount           int
+		ipVersion            flowpb.IPVersion
+		since                time.Duration
+		until                time.Duration
+		sourceCIDR, destCIDR string
+	}{}
+}


### PR DESCRIPTION
`fake flow` blows up on `--nodes-count 0` with a panic.

This validates `--nodes-count` before generation, and adds a test. Small fix, but it saves a kinda dumb crash.

Repro:
1. `cd cmd`
2. `go run . flow --nodes-count 0`

Before:
`panic: invalid argument to IntN`

After:
`--nodes-count must be at least 1`
